### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/infosec/osint.md
+++ b/infosec/osint.md
@@ -282,7 +282,7 @@ Subdomain enumiration
         * [lacnic.net](https://lacnic.net/cgi-bin/lacnic/whois) (Latin America, Caribbean)
         * [www.afrinic.net](https://www.afrinic.net/en/services/whois-query) (Africa)
 
-    * `curl -s http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2.zip | gunzip | cut -d"," -f3 | sed 's/"//g' | sort -u | grep -i twitter` (MaxMind geo-ip base)
+    * `curl -s https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2.zip | gunzip | cut -d"," -f3 | sed 's/"//g' | sort -u | grep -i twitter` (MaxMind geo-ip base)
 
 * **reverse ip lookup**
 


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).